### PR TITLE
Urlgen fix workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ main, steph0de-patch-1 ]
+    branches: [ main, urlgen-fix-* ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,9 +15,10 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
-
+  build-and-push-docker-image:
+    name: Build Docker image and push to repositories
     runs-on: ubuntu-latest
+    
     permissions:
       contents: read
       packages: write
@@ -26,6 +27,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -34,7 +39,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -53,3 +58,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+


### PR DESCRIPTION
Fixed workflow while trying to push the OCI image to the Github package repo.  
Replacing the use of GITHUB_TOKEN in favor of a dedicated secret (GHCR_PAT)